### PR TITLE
Fix bug with Entra ID token

### DIFF
--- a/src/cosmos.py
+++ b/src/cosmos.py
@@ -9,6 +9,7 @@ import json
 
 def runDemo(endpoint, table_name, writeOutput):
     # <create_client>
+    # Retrieves an Azure Storage token instead of Azure Cosmos DB for Table
     credential = DefaultAzureCredential()
 
     client = TableServiceClient(endpoint, credential=credential)


### PR DESCRIPTION
The token is errantly scoped to Azure Storage only. We need a token for Azure Cosmos DB for Table.